### PR TITLE
fix: fix if host is listen on ip.IsUnspecified

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.20
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,12 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: "1.22"
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.20
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -6,12 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: "1.22"
 
       - uses: actions/cache@v2
         with:

--- a/entity/entity.go
+++ b/entity/entity.go
@@ -65,7 +65,8 @@ func buildPath(info *registry.Info) (string, error) {
 		if port == "" {
 			return "", fmt.Errorf("registry info addr missing port")
 		}
-		if host == "" {
+		ip := net.ParseIP(host)
+		if ip == nil || ip.IsUnspecified() {
 			ipv4, err := utils.GetLocalIPv4Address()
 			if err != nil {
 				return "", fmt.Errorf("get local ipv4 error, cause %w", err)


### PR DESCRIPTION
#### What type of PR is this?

fix: A bug fix

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

When the host machine where the current instance is located does not support IPv6 addresses, the instance registration will use the IPv4 default address "0.0.0.0" for registration, resulting in the registered instance being "0.0.0.0" instead of the actual IP address.

// IsUnspecified reports whether ip is an unspecified address, either the IPv4 address "0.0.0.0" or the IPv6 address "::".

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


ref: https://github.com/hertz-contrib/registry/pull/112